### PR TITLE
Fix "gpg" usage to stop relying on deprecated and insecure behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ WORKDIR /app
 
 RUN curl -fSL "https://rocket.chat/releases/${RC_VERSION}/download" -o rocket.chat.tgz \
 &&  curl -fSL "https://rocket.chat/releases/${RC_VERSION}/asc" -o rocket.chat.tgz.asc \
-&&  gpg --verify rocket.chat.tgz.asc \
+&&  gpg --batch --verify rocket.chat.tgz.asc rocket.chat.tgz \
 &&  tar zxvf rocket.chat.tgz \
-&&  rm rocket.chat.tgz  \
+&&  rm rocket.chat.tgz rocket.chat.tgz.asc \
 &&  cd bundle/programs/server \
 &&  npm install
 


### PR DESCRIPTION
See also docker-library/official-images#1420.