### PR TITLE
Update to 0.23.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ VOLUME /app/uploads
 # gpg: key 4FD08014: public key "Rocket.Chat Buildmaster <buildmaster@rocket.chat>" imported
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 0E163286C20D07B9787EBE9FD7F9D0414FD08104
 
-ENV RC_VERSION 0.22.0
+ENV RC_VERSION 0.23.0
 
 WORKDIR /app
 


### PR DESCRIPTION
I noticed [Rocket.Chat 0.23.0 was released](https://github.com/RocketChat/Rocket.Chat/releases/tag/0.23.0). This is a version bump in the Docker image.