### PR TITLE
Revert #20 (7d819cdc7cbc4fced21d28ef2926883a10b88d11) and switch to "node:0.10-slim" instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,15 @@
-FROM debian:jessie
+FROM node:0.10-slim
 
 # crafted and tuned by pierre@ozoux.net and sing.li@rocket.chat
 MAINTAINER buildmaster@rocket.chat
 
-# gpg: key 4FD08014: public key "Rocket.Chat Buildmaster <buildmaster@rocket.chat>" imported
-RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 0E163286C20D07B9787EBE9FD7F9D0414FD08104
-
-# gpg keys listed at https://github.com/nodejs/node
-RUN for key in \
-      9554F04D7259F04124DE6B476D5A82AC7E37093B \
-      94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-      0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
-      FD3A5288F042B6850C66B31F09FE44734EB7990E \
-      71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-      DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-      B9AE9905FFD7803F25714661B63B535A4C206CA9 \
-      C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-    ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
-    done
-
-ENV NODE_VERSION=0.10.43 \
-    NPM_VERSION=2.14.1
-
-RUN apt-get update && apt-get install -y curl ca-certificates imagemagick --no-install-recommends \
- && rm -rf /var/lib/apt/lists/* \
- && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
- && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
- && gpg --verify SHASUMS256.txt.asc \
- && grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - \
- && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
- && rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc \
- && npm install -g npm@"$NPM_VERSION" \
- && npm cache clear \
- && groupadd -r rocketchat \
- && useradd -r -g rocketchat rocketchat
+RUN groupadd -r rocketchat \
+&&  useradd -r -g rocketchat rocketchat
 
 VOLUME /app/uploads
+
+# gpg: key 4FD08014: public key "Rocket.Chat Buildmaster <buildmaster@rocket.chat>" imported
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 0E163286C20D07B9787EBE9FD7F9D0414FD08104
 
 ENV RC_VERSION 0.31.0
 


### PR DESCRIPTION
As discussed in https://github.com/RocketChat/Docker.Official.Image/pull/20#issuecomment-222171055