### PR TITLE
Change UID and GID to never clash with system uid/gid (usually)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM node:4-slim
 # crafted and tuned by pierre@ozoux.net and sing.li@rocket.chat
 MAINTAINER buildmaster@rocket.chat
 
-RUN groupadd -r rocketchat \
-&&  useradd -r -g rocketchat rocketchat
+RUN groupadd -g 99999 -r rocketchat \
+&&  useradd -u 99999 -r -g rocketchat rocketchat
 
 VOLUME /app/uploads
 


### PR DESCRIPTION
This is something that bugged me. I run a rocketchat server and the UID clashes with my user, whom has passwordless sudo access!