### PR TITLE
Update from Node 8.11 to the latest 8.x (8.11 is no longer supported)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.11-slim
+FROM node:8-slim
 
 # crafted and tuned by pierre@ozoux.net and sing.li@rocket.chat
 MAINTAINER buildmaster@rocket.chat


### PR DESCRIPTION
See also https://travis-ci.org/docker-library/official-images/builds/449066913 (from https://github.com/docker-library/official-images/pull/5020).