### PR TITLE
Update MongoDB version example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Stop the containers with:
 ### Individual containers
 First, start an instance of mongo:
 
-    docker run --name db -d mongo:3.2 mongod --smallfiles
+    docker run --name db -d mongo:4.0 mongod --smallfiles
 
 Then start Rocket.Chat linked to this mongo instance:
 


### PR DESCRIPTION
Closes #62 

Version 3.2 still works but it is not the recommended anymore.