### PR TITLE
Use "debian:jessie-slim" and simplify slightly further

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,23 @@
-FROM debian:jessie
-
 ## Start Hack
-## All of this needed because of missing 8.11.x tag.  Once we update to 8.15 we can resume using Dockerfile.old or remove hack and use FROM node:8.15-slim
+FROM debian:jessie-slim
+## All of this needed because of missing 8.11.x tag.  Once we update to 8.15+ we can resume using Dockerfile.old or remove hack and use FROM node:8-slim
 
 ## Installing Node.js
-
-# gpg keys listed at https://github.com/nodejs/node
-RUN set -ex \
- && for key in \
-      94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-      FD3A5288F042B6850C66B31F09FE44734EB7990E \
-      71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-      DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-      C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-      B9AE9905FFD7803F25714661B63B535A4C206CA9 \
-      56730D5401028683275BD23C23EFEFE93C4CFFFE \
-      77984A986EBC2AA786BC0F66B01FBB92821C587A \
-      8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
-    ; do \
-    gpg --keyserver pool.sks-keyservers.net --recv-keys "$key"; \
-    done
-
+RUN gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys DD8F2338BAE7501E3DD5AC78C273792F7D83545D
 ENV NODE_VERSION 8.11.4
 ENV NODE_ENV production
-
-RUN set -x \
- && apt-get update && apt-get install -y curl ca-certificates imagemagick --no-install-recommends \
- && rm -rf /var/lib/apt/lists/* \
- && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
- && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
- && gpg --verify SHASUMS256.txt.asc \
- && grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - \
- && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
- && rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc \
- && npm cache clear --force
-
- ## End Hack
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends ca-certificates curl; \
+	rm -rf /var/lib/apt/lists/*; \
+	curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz"; \
+	curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc"; \
+	gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc; \
+	grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt | sha256sum -c -; \
+	tar -xf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 --no-same-owner; \
+	rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc SHASUMS256.txt; \
+	npm cache clear --force
+## End Hack
 
 ## Actual Rocket.Chat stuff
 MAINTAINER buildmaster@rocket.chat


### PR DESCRIPTION
(This builds on top of what was added in https://github.com/RocketChat/Docker.Official.Image/pull/68.)

This is inspired directly by https://github.com/nodejs/docker-node/blob/72dd945d29dee5afa73956ebc971bf3a472442f7/8/slim/Dockerfile, which is the original Dockerfile for the "node:8.11-slim" image this was based on previously.

The end result is ~751MB (current `rocket.chat:latest` is ~789MB).