### PR TITLE
Adjust RC-skipping code to also skip Beta releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ VOLUME /app/uploads
 # gpg: key 4FD08014: public key "Rocket.Chat Buildmaster <buildmaster@rocket.chat>" imported
 RUN gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 0E163286C20D07B9787EBE9FD7F9D0414FD08104
 
-ENV RC_VERSION 1.0.0-beta.2
+ENV RC_VERSION 0.74.3
 
 WORKDIR /app
 

--- a/update.sh
+++ b/update.sh
@@ -10,7 +10,7 @@ current="$(
 			}
 		' \
 		| sort -uV \
-		| grep -vE -- '-(rc|beta)' \
+		| grep -vE -- '-(rc|alpha|beta)' \
 		| tail -1
 )"
 

--- a/update.sh
+++ b/update.sh
@@ -10,7 +10,7 @@ current="$(
 			}
 		' \
 		| sort -uV \
-		| grep -v -- -rc \
+		| grep -vE -- '-(rc|beta)' \
 		| tail -1
 )"
 


### PR DESCRIPTION
cc @geekgonecrazy 

(refs https://github.com/docker-library/official-images/pull/5590#issuecomment-475418588)

We were already ignoring `-rc`, so I just updated that to also ignore `-beta`.  Any other strings I should throw in here while we're at it?