### PR TITLE
Add missing fontconfig package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV NODE_VERSION 8.11.4
 ENV NODE_ENV production
 RUN set -eux; \
 	apt-get update; \
-	apt-get install -y --no-install-recommends ca-certificates curl; \
+	apt-get install -y --no-install-recommends ca-certificates curl fontconfig; \
 	rm -rf /var/lib/apt/lists/*; \
 	curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz"; \
 	curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc"; \


### PR DESCRIPTION
Rocket.Chat server generates for the mobil devices avatar icons with letters, when the users did not upload pictures. For generating this avatars the app need fonts, which weren't included yet in the Rocket.Chat docker image.
Issue: https://github.com/RocketChat/Rocket.Chat.iOS/issues/2393