### PR TITLE
Fix invalid traefik label

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -9,7 +9,7 @@ services:
     restart: on-failure
     labels:
       traefik.enable: 'true'
-      traefik.routers.rocketchat.rule: Host(`${DOMAIN}`)
+      traefik.http.routers.rocketchat.rule: Host(`${DOMAIN}`)
       traefik.http.routers.rocketchat.tls: 'true'
       traefik.http.routers.rocketchat.entrypoints: https
       traefik.http.routers.rocketchat.tls.certresolver: le


### PR DESCRIPTION
Previous label does not appear to conform to Traefik's documented labels:

https://doc.traefik.io/traefik/reference/dynamic-configuration/docker/

This results in the `traefik` container attempts to fetch a certificate for something other than the hostname declared in `${DOMAIN}`:
```
redacted-chat-traefik-1  | time="2022-06-28T22:20:44Z" level=error msg="Unable to obtain ACME certificate for domains \"rocketchat-redacted-chat\": unable to generate a certificate for the domains [rocketchat-redacted-chat]: acme: error: 400 :: POST :: https://acme-v02.api.letsencrypt.org/acme/new-order :: urn:ietf:params:acme:error:rejectedIdentifier :: Error creating new order :: Cannot issue for \"rocketchat-redacted-chat\": Domain name needs at least one dot" ACME CA="https://acme-v02.api.letsencrypt.org/directory" routerName=rocketchat@docker rule="Host(`rocketchat-redacted-chat`)" providerName=acmedns.acme
```

Updating the label to conform to Traefik's documentation appears to resolve the issue and result in the expected behavior.