### PR TITLE
feature(Dockerfile): set nodejs version as argument

### DIFF
--- a/3.18/Dockerfile
+++ b/3.18/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:buster-slim
 
 ## Installing Node.js
 ENV NODE_ENV production
-ENV NODE_VERSION 12.22.1
+ARG NODE_VERSION=12.22.1
 
 # Node installation based on https://github.com/nodejs/docker-node/blob/66b46292a6e5dd5856b1d5204dc51547c80eb17a/12/buster-slim/Dockerfile
 RUN ARCH="x64" \

--- a/4.6/Dockerfile
+++ b/4.6/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:buster-slim
 
 ## Installing Node.js
 ENV NODE_ENV production
-ENV NODE_VERSION 14.18.3
+ARG NODE_VERSION=14.18.3
 
 # Node installation based on https://github.com/nodejs/docker-node/blob/66b46292a6e5dd5856b1d5204dc51547c80eb17a/12/buster-slim/Dockerfile
 RUN ARCH="x64" \

--- a/4.6/Dockerfile
+++ b/4.6/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:buster-slim
 
 ## Installing Node.js
 ENV NODE_ENV production
-ARG NODE_VERSION=14.18.3
+ARG NODE_VERSION=14.20.0
 
 # Node installation based on https://github.com/nodejs/docker-node/blob/66b46292a6e5dd5856b1d5204dc51547c80eb17a/12/buster-slim/Dockerfile
 RUN ARCH="x64" \

--- a/4.7/Dockerfile
+++ b/4.7/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:buster-slim
 
 ## Installing Node.js
 ENV NODE_ENV production
-ENV NODE_VERSION 14.18.3
+ARG NODE_VERSION=14.18.3
 
 # Node installation based on https://github.com/nodejs/docker-node/blob/66b46292a6e5dd5856b1d5204dc51547c80eb17a/12/buster-slim/Dockerfile
 RUN ARCH="x64" \

--- a/4.7/Dockerfile
+++ b/4.7/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:buster-slim
 
 ## Installing Node.js
 ENV NODE_ENV production
-ARG NODE_VERSION=14.18.3
+ARG NODE_VERSION=14.20.0
 
 # Node installation based on https://github.com/nodejs/docker-node/blob/66b46292a6e5dd5856b1d5204dc51547c80eb17a/12/buster-slim/Dockerfile
 RUN ARCH="x64" \

--- a/4.8/Dockerfile
+++ b/4.8/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:buster-slim
 
 ## Installing Node.js
 ENV NODE_ENV production
-ENV NODE_VERSION 14.18.3
+ARG NODE_VERSION=14.18.3
 
 # Node installation based on https://github.com/nodejs/docker-node/blob/66b46292a6e5dd5856b1d5204dc51547c80eb17a/12/buster-slim/Dockerfile
 RUN ARCH="x64" \

--- a/4.8/Dockerfile
+++ b/4.8/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:buster-slim
 
 ## Installing Node.js
 ENV NODE_ENV production
-ARG NODE_VERSION=14.18.3
+ARG NODE_VERSION=14.20.0
 
 # Node installation based on https://github.com/nodejs/docker-node/blob/66b46292a6e5dd5856b1d5204dc51547c80eb17a/12/buster-slim/Dockerfile
 RUN ARCH="x64" \


### PR DESCRIPTION
I would like to use your rocket image as base image for my installation. It would be advantageous if the nodejs version is set as argument, so that it can be dynamically adjusted in the docker build in case of emerging security vulnerabilities.

As a concrete example, there is a security vulnerability in all nodejs versions that are `=<14.20.0`. In this case I need to build your image locally, push it to my registry and then reference it as base in my own image.