### PR TITLE
Add support for arm64 builds

### DIFF
--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -1,11 +1,16 @@
-FROM debian:buster-slim
+FROM debian:bullseye
 
 ## Installing Node.js
 ENV NODE_ENV production
 ENV NODE_VERSION 14.19.3
 
 # Node installation based on https://github.com/nodejs/docker-node/blob/66b46292a6e5dd5856b1d5204dc51547c80eb17a/12/buster-slim/Dockerfile
-RUN ARCH="x64" \
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+  amd64) ARCH='x64';; \
+  arm64) ARCH='arm64';; \
+  *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
   && set -eux \
   && apt-get update && apt-get install -y --no-install-recommends ca-certificates curl wget gnupg dirmngr xz-utils \
   && rm -rf /var/lib/apt/lists/* \
@@ -52,7 +57,13 @@ ENV RC_VERSION 5.0.1
 
 WORKDIR /app
 
-RUN set -eux \
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+  amd64) ARCH='x64';; \
+  arm64) ARCH='arm64';; \
+  *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  && set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends fontconfig \
   && aptMark="$(apt-mark showmanual)" \
@@ -66,7 +77,15 @@ RUN set -eux \
   && tar zxf rocket.chat.tgz \
   && rm rocket.chat.tgz rocket.chat.tgz.asc \
   && cd bundle/programs/server \
-  && npm install \
+  && npm install --arch=${ARCH} --force \
+  && cd npm/node_modules/sharp \
+  && npm set unsafe-perm true \
+  && npm install --arch=${ARCH} --force \
+  && cd /app/bundle/programs/server/npm/node_modules/bcrypt \
+  && npm install --arch=${ARCH} --force --build-from-source \
+  && cd /app/bundle/programs/server/npm/node_modules/meteor/accounts-password/node_modules/bcrypt \
+  && npm install --arch=${ARCH} --force --build-from-source \
+  && cd /app/bundle/programs/server \
   && apt-mark auto '.*' > /dev/null \
   && apt-mark manual $aptMark > /dev/null \
   && find /usr/local -type f -executable -exec ldd '{}' ';' \


### PR DESCRIPTION
Allow building Rocket.Chat for arm64 platform.
Changes made to the Dockerfile:
- Changed base image to provide a higher version of glibc.
- Check architecture compliance and store the result in env variable.
- Build some packages from sources as they do not provide arm64 versions.
Build tested on x86 and arm64.