### PR TITLE
Use MONGODB_VERSION in env.example

### DIFF
--- a/env.example
+++ b/env.example
@@ -18,7 +18,7 @@
 
 ### MongoDB configuration
 # MongoDB version/image tag
-#MONGODB_RELEASE=
+#MONGODB_VERSION=
 # See:- https://hub.docker.com/r/bitnami/mongodb
 
 ### Traefik config (if enabled)


### PR DESCRIPTION
In compose.yml the environment variable for the MongoDB version is "MONGODB_VERSION". The previous env.example uses "MONGODB_RELEASE". This PR fixes the example.