### PR TITLE
Update compose.yml

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -21,7 +21,7 @@ services:
       ROOT_URL: ${ROOT_URL:-http://localhost:${HOST_PORT:-3000}}
       PORT: ${PORT:-3000}
       DEPLOY_METHOD: docker
-      DEPLOY_PLATFORM: ${DEPLOY_PLATFORM}
+      DEPLOY_PLATFORM: ${DEPLOY_PLATFORM:-linux}
     depends_on:
       - mongodb
     expose:


### PR DESCRIPTION
Implement fix to fallback to `linux` if the env variable `DEPLOY_PLATFORM` was not set by the user.

This fixes the warning message when `docker compose config` is run on the provided `docker-comose.yml` file to validate its proper syntax. 

The command will print the following warning message:

````
msg="The \"DEPLOY_PLATFORM\" variable is not set. Defaulting to a blank string."
````