### PR TITLE
Traefik changes + Restart Policy

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -4,7 +4,7 @@ volumes:
 services:
   rocketchat:
     image: registry.rocket.chat/rocketchat/rocket.chat:${RELEASE:-latest}
-    restart: on-failure
+    restart: always
     labels:
       traefik.enable: "true"
       traefik.http.routers.rocketchat.rule: Host(`${DOMAIN}`)
@@ -31,7 +31,7 @@ services:
 
   mongodb:
     image: docker.io/bitnami/mongodb:${MONGODB_VERSION:-4.4}
-    restart: on-failure
+    restart: always
     volumes:
       - mongodb_data:/bitnami/mongodb
     environment:

--- a/compose.yml
+++ b/compose.yml
@@ -30,7 +30,7 @@ services:
       - "${BIND_IP:-0.0.0.0}:${HOST_PORT:-3000}:${PORT:-3000}"
 
   mongodb:
-    image: docker.io/bitnami/mongodb:${MONGODB_VERSION:-4.4}
+    image: docker.io/bitnami/mongodb:${MONGODB_VERSION:-5.0}
     restart: always
     volumes:
       - mongodb_data:/bitnami/mongodb

--- a/traefik.yml
+++ b/traefik.yml
@@ -5,18 +5,23 @@ volumes:
 
 services:
   traefik:
-    image: docker.io/traefik:${TRAEFIK_RELEASE:-v2.6.1}
+    image: docker.io/traefik:${TRAEFIK_RELEASE:-v2.9.8}
+    restart: always
     command:
-      - --api.insecure=false
-      - --providers.docker=true
-      - --providers.docker.exposedbydefault=false
-      - --entrypoints.https.address=:443
-      - --certificatesresolvers.le.acme.tlschallenge=true
-      - --certificatesresolvers.le.acme.email=${LETSENCRYPT_EMAIL?need email for cert expiry notiications}
-      - --certificatesresolvers.le.acme.storage=/letsencrypt/acme.json
+     - --api.insecure=false
+     - --providers.docker=true
+     - --providers.docker.exposedbydefault=false
+     - --entrypoints.web.address=:80
+     - --entrypoints.web.http.redirections.entryPoint.to=https
+     - --entrypoints.web.http.redirections.entryPoint.scheme=https
+     - --entrypoints.https.address=:443
+     - --certificatesresolvers.le.acme.tlschallenge=true
+     - --certificatesresolvers.le.acme.email=${LETSENCRYPT_EMAIL?need email for cert expiry notifications}
+     - --certificatesresolvers.le.acme.storage=/letsencrypt/acme.json
     ports:
       - 80:80
       - 443:443
     volumes:
       - traefik:/letsencrypt:rw
       - /run/docker.sock:/var/run/docker.sock:ro
+    


### PR DESCRIPTION
I noticed that in some circumstances, traefik will not bind to port 80 if it's not explicitly defined a route for that port.

It worked initially, but for some reason it stopped binding to port 80, so this set of new instructions will make sure port 80/web is mapped and always redirecting to 443/websecure

Also, set restart policy to `always` in both traefik and docker-compose.yml, as it was not starting at reboot.