### PR TITLE
add deno to v7 container image

### DIFF
--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -57,6 +57,9 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   | xargs -r apt-mark manual \
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 
+# Deno installation based on https://github.com/denoland/deno_docker?tab=readme-ov-file#using-your-own-base-image
+COPY --from=denoland/deno:bin-1.37.1 /deno /usr/local/bin/deno
+
 RUN groupadd -r rocketchat \
   && useradd -r -g rocketchat rocketchat \
   && mkdir -p /app/uploads \


### PR DESCRIPTION
Apparently deno is now required to run some apps from the marketplace (like jitsi) https://docs.rocket.chat/docs/deploy-with-ubuntu#install-deno

It has to be exactly version 1.37.1 as per https://github.com/RocketChat/Rocket.Chat/issues/33140