### PR TITLE
chore: move `RC_VERSION` as down as possible

### DIFF
--- a/templates/node14/Dockerfile
+++ b/templates/node14/Dockerfile
@@ -1,7 +1,5 @@
 FROM debian:bullseye-slim
 
-ENV RC_VERSION 6
-
 ## Installing Node.js
 ENV NODE_ENV production
 ENV NODE_VERSION 14
@@ -51,6 +49,8 @@ RUN groupadd -r rocketchat \
 VOLUME /app/uploads
 
 WORKDIR /app
+
+ENV RC_VERSION 6
 
 RUN set -eux \
   && apt-get update \

--- a/templates/node20/Dockerfile
+++ b/templates/node20/Dockerfile
@@ -1,7 +1,5 @@
 FROM debian:bookworm-slim
 
-ENV RC_VERSION 7
-
 ## Installing Node.js
 ENV NODE_ENV production
 ENV NODE_VERSION 20
@@ -93,6 +91,8 @@ RUN groupadd -r rocketchat \
 VOLUME /app/uploads
 
 WORKDIR /app
+
+ENV RC_VERSION 7
 
 RUN set -eux \
   && apt-get update \


### PR DESCRIPTION
Address some of the comments from https://github.com/docker-library/official-images/pull/17984#issuecomment-2518668630