### PR TITLE
ci: Remove tj-actions/changed-files github action since it's compromised

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Calculate file differences
         id: diff
-        uses: tj-actions/changed-files@v45
+        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45.0.1
         with:
           json: true
           escape_json: false


### PR DESCRIPTION
This PR removes tj-actions because it was compromised and it's printing github secrets in the build output. We are replacing this action by the one created by the security company that detected the threat.
https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised