### PR TITLE
chore: pin gitHub actions to SHA hashes

### DIFF
--- a/.github/workflows/automatic-updates.yml
+++ b/.github/workflows/automatic-updates.yml
@@ -10,10 +10,10 @@ jobs:
     if: github.repository_owner == 'rocketchat'
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run automation script
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         id: updt
         with:
           result-encoding: string
@@ -23,7 +23,7 @@ jobs:
 
       - name: Create update PR
         id: cpr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GH_API_TOKEN }}
           author: "rocketchat-github-ci <buildmaster@rocket.chat>"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Calculate file differences
         id: diff
@@ -36,7 +36,7 @@ jobs:
           escape_json: false
 
       - name: Generate testing matrix
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         id: generator
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Get short node version
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         id: short-version
         with:
           result-encoding: string
@@ -72,10 +72,10 @@ jobs:
             return `${version[0]}.${version[1]}`
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           push: false
           load: true
@@ -91,7 +91,7 @@ jobs:
         run: docker compose up -d
 
       - name: Wait for Rocket.Chat to start up
-        uses: cygnetdigital/wait_for_response@v2.0.0
+        uses: cygnetdigital/wait_for_response@510ed9823ee9c5f876e57d25bd87c575032d8156 # v2.0.0
         with:
           url: 'http://localhost:3000/health'
           responseCode: '200'

--- a/.github/workflows/official-pr.yml
+++ b/.github/workflows/official-pr.yml
@@ -20,14 +20,14 @@ jobs:
 
     steps:
       - name: Checkout the Docker.Official.Image repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: Docker.Official.Image
           ref: ${{ github.base_ref }}
           fetch-depth: 50
 
       - name: Checkout the official-images repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: official-images
           repository: docker-library/official-images
@@ -39,7 +39,7 @@ jobs:
 
       - name: Create PR in official-images
         id: create-pr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GH_API_TOKEN }}
           push-to-fork: rocketchat/official-images
@@ -56,7 +56,7 @@ jobs:
           echo "Pull Request URL - ${{ steps.create-pr.outputs.pull-request-url }}"
 
       - name: Create PR comment
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         if: ${{ steps.create-pr.outputs.pull-request-url != '' }}
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -65,4 +65,4 @@ jobs:
 
       - name: Dump context
         if: always()
-        uses: crazy-max/ghaction-dump-context@v2
+        uses: crazy-max/ghaction-dump-context@5355a8e5e6ac5a302e746a1c4b7747a0393863c8 # v2.3.0


### PR DESCRIPTION
# Proposed changes
This PR replaces mutable tag references with immutable commit SHA pins for all third-party GitHub Actions, as part of a supply chain security hardening effort.

Each workflow file now references the exact commit SHA of the desired action version instead of a floating tag. This guarantees that the same code is always executed regardless of whether the version tag is moved or the action's repository is modified after pinning.

# Issue(s)
[SB-958](https://rocketchat.atlassian.net/browse/SB-958)

[SB-958]: https://rocketchat.atlassian.net/browse/SB-958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ