### PR TITLE
chore: apply least privilege permissions to github actions

### DIFF
--- a/.github/workflows/automatic-updates.yml
+++ b/.github/workflows/automatic-updates.yml
@@ -4,10 +4,14 @@ on:
   schedule:
     - cron: "*/15 * * * *"
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'rocketchat'
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,10 +19,15 @@ on:
       - compose.yml
       - ".github/workflows/build-test.yml"
 
+permissions: {}
+
 jobs:
   gen-matrix:
     name: generate-matrix
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
 
     steps:
       - name: Checkout
@@ -57,6 +62,8 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.gen-matrix.outputs.matrix) }}

--- a/.github/workflows/official-pr.yml
+++ b/.github/workflows/official-pr.yml
@@ -11,11 +11,14 @@ on:
       - "!templates/**"
       - "stackbrew.js"
 
+permissions: {}
+
 jobs:
   pr:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'rocketchat' && github.event.pull_request.merged_by != ''
     permissions:
+      contents: read
       pull-requests: write
 
     steps:


### PR DESCRIPTION
## Proposed changes
This PR applies the principle of least privilege to `GITHUB_TOKEN` permissions across all GitHub Actions workflows by setting `permissions: {}` globally and explicitly re-granting only the minimum permissions required per job, as part of a supply chain security hardening effort.

Workflows relied on GitHub’s default token scopes, which may grant more access than most jobs actually need. Scoping permissions at the job level reduces the attack surface in the event that a GitHub Action, third-party dependency, or CI component is compromised, helping mitigate the impact of potential supply chain attacks and limiting unnecessary repository access.

This change only affects the permissions granted to the workflow `GITHUB_TOKEN`. Operations authenticated using explicitly configured Personal Access Tokens (PATs) continue to have the scopes assigned to those tokens and are not affected by workflow permissions settings.

## Issue(s)
[SB-975](https://rocketchat.atlassian.net/browse/SB-975)

[SB-975]: https://rocketchat.atlassian.net/browse/SB-975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ